### PR TITLE
Fixed copying header files to output dir

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -480,14 +480,8 @@ function package() {
     pushd src >/dev/null
 
       # Find and copy header files
-      find webrtc -name *.h -exec $CP --parents '{}' $outdir/$label/include ';'
+      find . -name '*.h' | xargs -I '{}' $CP --parent '{}' $outdir/$label/include 
 
-      # Find and copy dependencies
-      # The following build dependencies were excluded: gflags, ffmpeg, openh264, openmax_dl, winsdk_samples, yasm
-      find third_party -name *.h -o -name README -o -name LICENSE -o -name COPYING | \
-        grep -E 'boringssl|expat/files|jsoncpp/source/json|libjpeg|libjpeg_turbo|libsrtp|libyuv|libvpx|opus|protobuf|usrsctp/usrsctpout/usrsctpout' | \
-        grep -v /third_party | \
-        xargs -I '{}' $CP --parents '{}' $outdir/$label/include
     popd >/dev/null
 
     # Find and copy libraries


### PR DESCRIPTION
I was getting following error, while using the build script:
```
find: paths must precede expression: typedefs.h
Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec|time] [path...] [expression]
```
Also output `include` directory was empty:
```
sch@sch-Predator-G3-572-docker:~/webrtcbuilds$ ls -la out/webrtc-22359-3285897-linux-x64/include/
total 8
drwxr-xr-x 2 sch 1000 4096 Mar  9 13:23 .
drwxr-xr-x 4 sch 1000 4096 Mar  9 13:23 ..
```
After the fix:
```
sch@sch-Predator-G3-572-docker:~/webrtcbuilds$ ls -la out/webrtc-22364-d4bc01b-linux-x64/include/
total 140
drwxr-xr-x 28 sch 1000  4096 Mar  9 14:40 .
drwxr-xr-x  4 sch 1000  4096 Mar  9 14:39 ..
drwxr-xr-x 10 sch 1000  4096 Mar  9 14:39 api
drwxr-xr-x  4 sch 1000  4096 Mar  9 14:40 audio
drwxr-xr-x 34 sch 1000  4096 Mar  9 14:40 base
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:39 build
drwxr-xr-x  4 sch 1000  4096 Mar  9 14:40 buildtools
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:39 call
drwxr-xr-x  7 sch 1000  4096 Mar  9 14:39 common_audio
-rw-r--r--  1 sch 1000 21288 Mar  9 14:40 common_types.h
drwxr-xr-x  5 sch 1000  4096 Mar  9 14:39 common_video
drwxr-xr-x  5 sch 1000  4096 Mar  9 14:40 examples
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:40 logging
drwxr-xr-x  5 sch 1000  4096 Mar  9 14:39 media
drwxr-xr-x 17 sch 1000  4096 Mar  9 14:40 modules
drwxr-xr-x  2 sch 1000  4096 Mar  9 14:40 ortc
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:39 out
drwxr-xr-x  5 sch 1000  4096 Mar  9 14:40 p2p
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:39 pc
drwxr-xr-x  6 sch 1000  4096 Mar  9 14:40 rtc_base
drwxr-xr-x  7 sch 1000  4096 Mar  9 14:40 rtc_tools
drwxr-xr-x  4 sch 1000  4096 Mar  9 14:39 sdk
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:40 stats
drwxr-xr-x  4 sch 1000  4096 Mar  9 14:39 system_wrappers
drwxr-xr-x  9 sch 1000  4096 Mar  9 14:40 test
drwxr-xr-x  7 sch 1000  4096 Mar  9 14:39 testing
drwxr-xr-x 94 sch 1000  4096 Mar  9 14:40 third_party
drwxr-xr-x 18 sch 1000  4096 Mar  9 14:40 tools
-rw-r--r--  1 sch 1000  3734 Mar  9 14:40 typedefs.h
drwxr-xr-x  3 sch 1000  4096 Mar  9 14:39 video
```