### PR TITLE
Fixed copying header files to output dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,7 +111,7 @@ compile $PLATFORM $OUTDIR "$TARGET_OS" "$TARGET_CPU" "$BLACKLIST"
 # label is <projectname>-<rev-number>-<short-rev-sha>-<target-os>-<target-cpu>
 LABEL=$PROJECT_NAME-$REVISION_NUMBER-$(short-rev $REVISION)-$TARGET_OS-$TARGET_CPU
 echo "Packaging WebRTC: $LABEL"
-package $PLATFORM $OUTDIR $LABEL $DIR/resource
+package $PLATFORM $OUTDIR $LABEL $DIR/resource $REVISION_NUMBER
 manifest $PLATFORM $OUTDIR $LABEL
 
 echo Build successful


### PR DESCRIPTION
I was getting following error, while using the build script:
```
find: paths must precede expression: typedefs.h
Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec|time] [path...] [expression]
```
Also output `include` directory was empty:
```
sch@sch-Predator-G3-572-docker:~/webrtcbuilds$ ls -la out/webrtc-22359-3285897-linux-x64/include/
total 8
drwxr-xr-x 2 sch 1000 4096 Mar  9 13:23 .
drwxr-xr-x 4 sch 1000 4096 Mar  9 13:23 ..
```
The problem is described here: https://github.com/vsimon/webrtcbuilds/commit/f5d01cbc94db92c6205a745affbe7b92cc4eb311#diff-a188fc26ef16ad3194c8d957e9e0cd3dR322
I have applied simmilar fix. After the fix:
```
sch@sch-Predator-G3-572-docker:~/code/bin/webrtc-builds$ ls -la out/webrtc-22412-19bea51-linux-x64/include/
total 236
drwxr-xr-x 28 sch 1000  4096 Mar 13 20:16 .
drwxr-xr-x  4 sch 1000  4096 Mar 13 20:16 ..
drwxr-xr-x 10 sch 1000 12288 Mar 13 20:16 api
drwxr-xr-x  4 sch 1000  4096 Mar 13 20:16 audio
drwxr-xr-x 34 sch 1000 28672 Mar 13 20:16 base
drwxr-xr-x  3 sch 1000  4096 Mar 13 20:16 build
drwxr-xr-x  4 sch 1000  4096 Mar 13 20:16 buildtools
drwxr-xr-x  3 sch 1000  4096 Mar 13 20:16 call
drwxr-xr-x  7 sch 1000  4096 Mar 13 20:16 common_audio
-rw-r--r--  1 sch 1000 21288 Mar 13 20:16 common_types.h
drwxr-xr-x  5 sch 1000  4096 Mar 13 20:16 common_video
drwxr-xr-x  6 sch 1000  4096 Mar 13 20:16 examples
drwxr-xr-x  3 sch 1000  4096 Mar 13 20:16 logging
drwxr-xr-x  5 sch 1000  4096 Mar 13 20:16 media
drwxr-xr-x 17 sch 1000  4096 Mar 13 20:16 modules
drwxr-xr-x  2 sch 1000  4096 Mar 13 20:16 ortc
drwxr-xr-x  3 sch 1000  4096 Mar 13 20:16 out
drwxr-xr-x  5 sch 1000  4096 Mar 13 20:16 p2p
drwxr-xr-x  3 sch 1000 12288 Mar 13 20:16 pc
drwxr-xr-x  6 sch 1000 32768 Mar 13 20:16 rtc_base
drwxr-xr-x  7 sch 1000  4096 Mar 13 20:16 rtc_tools
drwxr-xr-x  4 sch 1000  4096 Mar 13 20:16 sdk
drwxr-xr-x  3 sch 1000  4096 Mar 13 20:16 stats
drwxr-xr-x  4 sch 1000  4096 Mar 13 20:16 system_wrappers
drwxr-xr-x  9 sch 1000 12288 Mar 13 20:16 test
drwxr-xr-x  7 sch 1000  4096 Mar 13 20:16 testing
drwxr-xr-x 12 sch 1000  4096 Mar 13 20:16 third_party
drwxr-xr-x 18 sch 1000  4096 Mar 13 20:16 tools
-rw-r--r--  1 sch 1000  3734 Mar 13 20:16 typedefs.h
drwxr-xr-x  3 sch 1000  4096 Mar 13 20:16 video
```
Contents of the `third_party` dir:
```
sch@sch-Predator-G3-572-docker:~/code/bin/webrtc-builds$ ls -la out/webrtc-22412-19bea51-linux-x64/include/third_party/
total 48
drwxr-xr-x 12 sch 1000 4096 Mar 13 20:16 .
drwxr-xr-x 28 sch 1000 4096 Mar 13 20:16 ..
drwxr-xr-x  3 sch 1000 4096 Mar 13 20:16 boringssl
drwxr-xr-x  3 sch 1000 4096 Mar 13 20:16 expat
drwxr-xr-x  3 sch 1000 4096 Mar 13 20:16 ffmpeg
drwxr-xr-x  2 sch 1000 4096 Mar 13 20:16 libjpeg
drwxr-xr-x  3 sch 1000 4096 Mar 13 20:16 libjpeg_turbo
drwxr-xr-x  6 sch 1000 4096 Mar 13 20:16 libsrtp
drwxr-xr-x  4 sch 1000 4096 Mar 13 20:16 libvpx
drwxr-xr-x  5 sch 1000 4096 Mar 13 20:16 libyuv
drwxr-xr-x  3 sch 1000 4096 Mar 13 20:16 opus
drwxr-xr-x  8 sch 1000 4096 Mar 13 20:16 protobuf
```
Unfortunately I was unable to test a revision older than 19846, but it is unrelated to my changes. 
```
sch@sch-Predator-G3-572-docker:~/code/bin/webrtc-builds$ ./build.sh -e 1 -l jsoncpp -r 19845 
Host OS: linux
Target OS: linux
Target CPU: x64
Checking build environment dependencies
Checking depot-tools
Building revision: 19845
Could not get revision number
```
@auscaster How can I test revisions older than 19846?