### PR TITLE
Enable RTTI for WebRtc build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ while getopts :o:b:r:t:c:l:e:xd OPTION; do
   t) TARGET_OS=$OPTARG ;;
   c) TARGET_CPU=$OPTARG ;;
   l) BLACKLIST=$OPTARG ;;
-  e) ENABLE_RTTI=OPTARG ;;
+  e) ENABLE_RTTI=1 ;;
   x) BUILD_ONLY=1 ;;
   d) DEBUG=1 ;;
   ?) usage; exit 1 ;;

--- a/util.sh
+++ b/util.sh
@@ -239,6 +239,7 @@ function checkout() {
 function patch() {
   local platform="$1"
   local outdir="$2"
+  local rtti_enabled="$3"
 
   pushd $outdir/src >/dev/null
     # This removes the examples from being built.
@@ -251,11 +252,11 @@ function patch() {
 
     # Enable RTTI if required by removing the 'no_rtti' compiler flag.
     # This fixes issues when compiling WebRTC with other libraries that have RTTI enabled.
-    # if [ $ENABLE_RTTI = 1 ]; then
-    #   echo "Enabling RTTI"
-    #   sed -i.bak 's|"//build/config/compiler:no_rtti",|#"//build/config/compiler:no_rtti",|' \
-    #     build/config/BUILDCONFIG.gn
-    # fi
+    if [ "$rtti_enabled" = 1 ]; then
+      echo "Enabling RTTI"
+      sed -i.bak 's|"//build/config/compiler:no_rtti",|#"//build/config/compiler:no_rtti",|' \
+         build/config/BUILDCONFIG.gn
+    fi
   popd >/dev/null
 }
 


### PR DESCRIPTION
Built for Mac, used libsorcey static libraries (build libsourcey as a part of other Mac app). Encountered next issue: `"typeinfo for rtc::MessageHandler", referenced from...` during linkage...

It is necessary to enable WebRTC build with RTTI for the cases when you need subclass functions.
See https://groups.google.com/d/msg/discuss-webrtc/PniiO9BumHA/M0aadE0UHwAJ for details.

In general, another fix is possible (just uncomment corresponding lines and define env variable), but from other side -e option is useless (it is mentioned in documentation how to build WebRTC on libsourcey wiki).

It is important to note in documentation that revision 02ba69d (other revisions are possible, but fix one in documentation) must be used to build WebRTC for libsourcey, since latest revision of WebRTC is incompatible with libsourcey code.

Also, it makes sense to mention somewhere, that it is necessary to define COMBINE_LIBRARIES env variable to 1 (unfortunately, script doesn't work as expected even if variable defined).

As far as I can see build of WebRTC from original repo (https://github.com/vsimon/webrtcbuilds.git) works as expected without any issue?